### PR TITLE
Custom startup command

### DIFF
--- a/99-run.sh
+++ b/99-run.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+echo "Activating virtualenv"
+. /opt/omero/web/venv/bin/activate
+
 set -eu
 
-export PATH="/opt/omero/web/venv/bin:$PATH"
-python=/opt/omero/web/venv/bin/python
 omero=/opt/omero/web/OMERO.web/bin/omero
 cd /opt/omero/web
 echo "Starting OMERO.web"
-exec $python $omero web start --foreground
+exec python $omero web start --foreground

--- a/99-run.sh
+++ b/99-run.sh
@@ -7,5 +7,10 @@ set -eu
 
 omero=/opt/omero/web/OMERO.web/bin/omero
 cd /opt/omero/web
-echo "Starting OMERO.web"
-exec python $omero web start --foreground
+if [ $# -eq 0 ]; then
+    echo "Starting OMERO.web"
+    exec python $omero web start --foreground
+else
+    echo "execing custom command: $@"
+    exec "$@"
+fi


### PR DESCRIPTION
The final startup command can be overridden. E.g.
`docker run -it -p 4080:4080 --rm -e CONFIG_omero_web_debug=true -e omero.web.application_server=development -e OMEROHOST=merge-ci-devspace.openmicroscopy.org -e PYTHONPATH=/opt/omero/web/OMERO.web/lib/python omero-web-standalone python /opt/omero/web/OMERO.web/lib/python/omeroweb/manage.py runserver 4080`
As suggested by @will-moore, I couldn't get this to work though.