### PR TITLE
bin/omero: workaround for `python bin/omero` import usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-default-web-config.sh 98-cleanprevious.sh 99-run.sh /startup/
 ADD ice.config /opt/omero/web/OMERO.web/etc/
 
+# Workaround for replace_omero
+RUN rm /opt/omero/web/OMERO.web/bin/omero && ln -s /opt/omero/web/venv3/bin/omero /opt/omero/web/OMERO.web/bin/omero
+
 USER omero-web
 EXPOSE 4080
 VOLUME ["/opt/omero/web/OMERO.web/var"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/local/bin/dumb-init /bin/bash
 
 set -e
+source /opt/omero/web/venv3/bin/activate
 
 for f in /startup/*; do
     if [ -f "$f" -a -x "$f" ]; then


### PR DESCRIPTION
see:
 - https://github.com/manics/ansible-role-omero-web/pulls
 - https://github.com/ome/omero-server-docker/pull/34