### PR TITLE
Re-add ome.java role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,7 @@
 - hosts: localhost
   roles:
   - role: ome.omero_web
+  - role: ome.java
   vars:
     ice_version: "3.6"
     ice_install_devel: False

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,6 +6,9 @@
 - src: ome.ice
   version: 3.1.0
 
+- src: ome.java
+  version: 2.0.3
+
 - src: ome.omero_common
   version: 0.3.2
 


### PR DESCRIPTION
https://travis-ci.org/ome/omero-mapr/builds/615152318 failed with:

```
popen = <subprocess.Popen object at 0x7f74184f6f60>, out = b''
err = b'Joined session for be441579-3057-4f16-a1e0-e4659e525382@omero:4064. Idle timeout: 10 min. Current group: 004aacec-e3...tion("Java could not be found. (Executable=%s)" % command[0])\n
Exception: Java could not be found. (Executable=java)\n'
```