### PR TITLE
Configure custom OMERO.server port

### DIFF
--- a/60-default-web-config.sh
+++ b/60-default-web-config.sh
@@ -6,6 +6,15 @@ set -eu
 omero=/opt/omero/web/venv3/bin/omero
 
 OMEROHOST=${OMEROHOST:-}
+OMEROPORT=${OMEROPORT:-}
 if [ -n "$OMEROHOST" ]; then
-    $omero config set omero.web.server_list "[[\"$OMEROHOST\", 4064, \"omero\"]]"
+    if [ -n "$OMEROPORT" ]; then
+        $omero config set omero.web.server_list "[[\"$OMEROHOST\", \"$OMEROPORT\", \"omero\"]]"
+    else
+        $omero config set omero.web.server_list "[[\"$OMEROHOST\", 4064, \"omero\"]]"
+    fi
+else
+    if [-n "$OMEROPORT" ]; then
+        $omero config set omero.web.server_list "[[\"localhost\", \"$OMEROPORT\", \"omero\"]]"
+    fi
 fi


### PR DESCRIPTION
It would be useful to configure  a custom OMERO.server port as you do with the OMERO.server host.

I implemented it in ome_seadragon docker image (https://github.com/crs4/ome_seadragon-docker/commit/9fb282950de460940f9bac55bbf1f16ea7642d01) but I think it would be more appropriate to integrate this change into the "main" omero-web Docker image.

I needed this because I have multiple OMERO.servers running on the same Docker host and each one of them exposes ports that are different from the standard ones.