### PR TITLE
Unpin whitenoise and bump plugins

### DIFF
--- a/50-config.py
+++ b/50-config.py
@@ -9,12 +9,10 @@ from subprocess import call
 from re import sub
 
 
-CONFIG_OMERO = '/opt/omero/web/config/omero-web-config-update.sh'
 OMERO = '/opt/omero/web/venv3/bin/omero'
 
-if os.access(CONFIG_OMERO, os.X_OK):
-    rc = call([CONFIG_OMERO])
-    assert rc == 0
+rc = call([OMERO, 'load', '--glob', '/opt/omero/web/config/*.omero'])
+assert rc == 0
 
 for (k, v) in os.environ.items():
     if k.startswith('CONFIG_'):

--- a/standalone/01-default-webapps.omero
+++ b/standalone/01-default-webapps.omero
@@ -12,15 +12,13 @@ config append -- omero.web.apps '"omero_iviewer"'
 config set -- omero.web.viewer.view omero_iviewer.views.index
 config append -- omero.web.open_with '["omero_iviewer", "omero_iviewer_index", {"supported_objects":["images", "dataset", "well"], "script_url": "omero_iviewer/openwith.js", "label": "OMERO.iviewer"}]'
 
-#	# omero-mapr
-#	config append -- omero.web.apps '"omero_mapr"'
-#	config append -- omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
-#
-#	# omero-parade
-#	config append -- omero.web.apps '"omero_parade"'
-#	config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
-#
+# omero-mapr
+config append -- omero.web.apps '"omero_mapr"'
+config append -- omero.web.mapr.config '{"menu": "anyvalue", "config":{"default":["Any Value"], "all":[], "ns":["openmicroscopy.org/omero/client/mapAnnotation"], "label":"Any"}}'
+
+# omero-parade
+config append -- omero.web.apps '"omero_parade"'
+config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
+
 # Top links
-# config set -- omero.web.ui.top_links '[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}], ["Mapr", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}], ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}], ["Help", "https://help.openmicroscopy.org/", {"title":"Open OMERO user guide in a new tab", "target":"new"}]]'
-# No mapr
-config set -- omero.web.ui.top_links '[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}], ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}], ["Help", "https://help.openmicroscopy.org/", {"title":"Open OMERO user guide in a new tab", "target":"new"}]]'
+config set -- omero.web.ui.top_links '[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}], ["Mapr", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}], ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}], ["Help", "https://help.openmicroscopy.org/", {"title":"Open OMERO user guide in a new tab", "target":"new"}]]'

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -8,7 +8,7 @@ RUN /opt/omero/web/venv3/bin/pip install \
         django-cors-headers \
         'omero-figure>=4.2.dev1' \
         'omero-iviewer>=0.9.0.dev1' \
-        'whitenoise<4'
+        'whitenoise'
 
         #omero-fpbioimage \
         #omero-mapr \

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -6,15 +6,14 @@ USER root
 
 RUN /opt/omero/web/venv3/bin/pip install \
         django-cors-headers \
-        'omero-figure>=4.2.dev1' \
-        'omero-iviewer>=0.9.0.dev1' \
-        'whitenoise'
-
-        #omero-fpbioimage \
-        #omero-mapr \
-        #omero-parade \
-        #omero-webtagging-autotag \
-        #omero-webtagging-tagsearch \
+        omero-figure \
+        omero-iviewer \
+        omero-fpbioimage \
+        omero-mapr \
+        omero-parade \
+        omero-webtagging-autotag \
+        omero-webtagging-tagsearch \
+        whitenoise
 
 ADD 01-default-webapps.omero /opt/omero/web/config/
 


### PR DESCRIPTION
5.6 standalone web server is not serving static files. Whitenoise was previously pinned to `<4`.

Also: unpin and/or uncomment all omero plugins.

This would be worth a re-release of the 5.6 images.