### PR TITLE
pin django-cors-header for Django 1.11

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 USER root
 
 RUN /opt/omero/web/venv3/bin/pip install \
-        django-cors-headers \
+        'django-cors-headers<3.3' \
         omero-figure \
         omero-iviewer \
         omero-fpbioimage \


### PR DESCRIPTION
https://pypi.org/project/django-cors-headers/3.3.0/ dropped
supported for Django 1.11. Ping to earlier versions to prevent
a forced upgrade of Django to 3.x.

fix #50