### PR TITLE
Move unnecessary deps from production image into devtest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,16 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker tag $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD) $(REPO)/omero-web-standalone:$$MAJOR_MINOR
 
+	docker build --build-arg=PARENT_IMAGE=$(REPO)/omero-web-standalone:$(VERSION) -t $(REPO)/omero-web-devtest:$(VERSION)-$(BUILD) devtest
+	docker tag $(REPO)/omero-web-devtest:$(VERSION)-$(BUILD) $(REPO)/omero-web-devtest:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker tag $(REPO)/omero-web-devtest:$(VERSION)-$(BUILD) $(REPO)/omero-web-devtest:$$MAJOR_MINOR
+
 
 docker-build: docker-build-versions
 	docker tag $(REPO)/omero-web:$(VERSION)-$(BUILD) $(REPO)/omero-web:latest
 	docker tag $(REPO)/omero-web-standalone:$(VERSION)-$(BUILD) $(REPO)/omero-web-standalone:latest
+	docker tag $(REPO)/omero-web-devtest:$(VERSION)-$(BUILD) $(REPO)/omero-web-devtest:latest
 
 
 docker-push-versions:
@@ -98,6 +104,12 @@ endif
 	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
 	docker push $(REPO)/omero-web-standalone:$$MAJOR_MINOR
 
+	docker push $(REPO)/omero-web-devtest:$(VERSION)-$(BUILD)
+	docker push $(REPO)/omero-web-devtest:$(VERSION)
+	@MAJOR_MINOR=$(shell echo $(VERSION) | cut -f1-2 -d. );\
+	docker push $(REPO)/omero-web-devtest:$$MAJOR_MINOR
+
 docker-push: docker-push-versions
 	docker push $(REPO)/omero-web:latest
 	docker push $(REPO)/omero-web-standalone:latest
+	docker push $(REPO)/omero-web-devtest:latest

--- a/devtest/Dockerfile
+++ b/devtest/Dockerfile
@@ -1,0 +1,20 @@
+ARG PARENT_IMAGE=openmicroscopy/omero-web-standalone:latest
+FROM ${PARENT_IMAGE}
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+USER root
+
+RUN yum install -y -q \
+    java-1.8.0-openjdk \
+    patch \
+    redhat-lsb-core \
+    rsync \
+    tar \
+    unzip \
+    wget \
+    zip
+
+# Shouldn't be necessary any more since OMERO.web/bin/omero is a Python script but included anyway from previous image used in https://github.com/ome/omero-test-infra
+RUN rm /opt/omero/web/OMERO.web/bin/omero && ln -s /opt/omero/web/venv3/bin/omero /opt/omero/web/OMERO.web/bin/omero
+
+USER omero-web

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,7 +1,6 @@
 - hosts: localhost
   roles:
   - role: ome.omero_web
-  - role: ome.java
   vars:
     ice_version: "3.6"
     ice_install_devel: False


### PR DESCRIPTION
This is extracted from https://github.com/ome/omero-web-docker/pull/38

It moves `java/javac` into a devtest image, and adds other tools including `git`.
Note this is Java 8, in keeping with the current OMERO.web standalone image.

----
E.g. `make VERSION=x.y.z docker-build`
```
openmicroscopy/omero-web-devtest             x.y.z               b109930c8052        27 seconds ago      1.2GB
openmicroscopy/omero-web-devtest             x.y.z-0             b109930c8052        27 seconds ago      1.2GB
openmicroscopy/omero-web-standalone          x.y.z               d23d308c0d4f        9 minutes ago       869MB
openmicroscopy/omero-web-standalone          x.y.z-0             d23d308c0d4f        9 minutes ago       869MB
openmicroscopy/omero-web                     x.y.z               3331af321dd0        9 minutes ago       862MB
openmicroscopy/omero-web                     x.y.z-0             3331af321dd0        9 minutes ago       862MB
```