### PR TITLE
Add logging tip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To run the Docker image you can set a single OMERO.server to connect to by defin
         -p 4080:4080 \
         openmicroscopy/omero-web-standalone
 
-Alternative all configuration options can be set using environment variables, for example,
+Alternatively, all configuration options can be set using environment variables, for example,
 add the following arguments to the command above:
 
         -e CONFIG_omero_web_server__list='[["omero.example.org", 4064, "omero"]]' \

--- a/README.md
+++ b/README.md
@@ -42,21 +42,16 @@ To run the Docker image you can set a single OMERO.server to connect to by defin
         -p 4080:4080 \
         openmicroscopy/omero-web-standalone
 
-Alternative all configuration options can be set using environment variables, for example:
+Alternative all configuration options can be set using environment variables, for example,
+add the following arguments to the command above:
 
-    docker run -d --name omero-web \
         -e CONFIG_omero_web_server__list='[["omero.example.org", 4064, "omero"]]' \
         -e CONFIG_omero_web_debug=true \
-        -p 4080:4080 \
-        openmicroscopy/omero-web-standalone
 
-The `$OMERODIR` is `/opt/omero/web/OMERO.web/` so you can have the logs written to your host with:
+The `$OMERODIR` is `/opt/omero/web/OMERO.web/` so you can have the logs written to your host
+by adding:
 
-    docker run -d --name omero-web \
-        -e OMEROHOST=omero.example.org \
-        -p 4080:4080 \
-        -v /path/to/host/dir:/opt/omero/web/OMERO.web/var/logs
-        openmicroscopy/omero-web-standalone
+        -v /path/to/host/dir:/opt/omero/web/OMERO.web/var/logs \
 
 Minimal OMERO.web image: omero-web
 ----------------------------------

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Alternative all configuration options can be set using environment variables, fo
         -p 4080:4080 \
         openmicroscopy/omero-web-standalone
 
+The `$OMERODIR` is `/opt/omero/web/OMERO.web/` so you can have the logs written to your host with:
+
+    docker run -d --name omero-web \
+        -e OMEROHOST=omero.example.org \
+        -p 4080:4080 \
+        -v /path/to/host/dir:/opt/omero/web/OMERO.web/var/logs
+        openmicroscopy/omero-web-standalone
 
 Minimal OMERO.web image: omero-web
 ----------------------------------


### PR DESCRIPTION
For debugging, I found it useful to be able to access logs (https://forum.image.sc/t/opening-private-omero-within-qupath/54419/23)
To help myself and others do this easier in future, adding the tip to the README.
