### PR TITLE
Install version of ome.omero_web role with upgraded pip in venv

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -13,5 +13,4 @@
   version: 0.3.4
 
 - name: ome.omero_web
-  src: https://github.com/ome/ansible-role-omero-web/archive/5bd0f5985b6a3d7fc6bfb2dc35db2e463e7d952f.tar.gz
   version: 4.0.1


### PR DESCRIPTION
Also upgrade other roles to the latest released versions

This fix depends on https://github.com/ome/ansible-role-omero-web/pull/41 and is required to fix the broken CI builds (see https://github.com/sbesson/omero-web-docker/runs/3919241143?check_suite_focus=true)