### PR TITLE
Clean up yum caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,13 @@ ADD playbook.yml requirements.yml /opt/setup/
 
 RUN yum -y install epel-release \
     && yum -y install ansible sudo \
-    && ansible-galaxy install -p /opt/setup/roles -r requirements.yml
+    && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
+    && yum -y clean all \
+    && rm -fr /var/cache
 
-RUN ansible-playbook playbook.yml
+RUN ansible-playbook playbook.yml \
+    && yum -y clean all \
+    && rm -fr /var/cache
 
 RUN curl -L -o /usr/local/bin/dumb-init \
     https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \


### PR DESCRIPTION
As discussed in #67, it is possible to reduce the size of the docker image by up to 30% by cleaning the yum-caches in the same commands where yum installations are performed.
This PR modifies the Dockerfile to include a yum -y clean-cache and rm -rf /var/cache, to do this clean up.

At the current point in time this decreases the size of the resulting image from 1.29GB to 918 MB.

// Julian