### PR TITLE
Set locale to en_US.utf-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:centos7.9.2009@sha256:dead07b4d8ed7e29e98de0f4504d87e8880d4347859d839686a31da35a3b532f
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 
+ENV LANG en_US.utf-8
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup


### PR DESCRIPTION
Changes the locale from `POSIX` to `en_US.utf-8` which is expected by OMERO.web, by setting the `LANG ` environment variable. See [this thread](https://forum.image.sc/t/qupath-extension-biop-omero-cant-import-images-after-successful-login/76003/13?u=michele_bortolomeazz) on the image.sc forum for reference
See https://github.com/ome/omero-server-docker/pull/76#issue-1562133645 for the corresponding pull request for the OMERO.server docker.