### PR TITLE
Remove unnecessary ome.ice requirement

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,9 +3,6 @@
 - name: ome.basedeps
   version: 1.2.0
 
-- name: ome.ice
-  version: 4.3.0
-
 - src: ome.java
   version: 2.1.0
 


### PR DESCRIPTION
This is most likely coming from Python 2.x times and the Ice Python requirement should be installed as part of the ome.omero-web role