### PR TITLE
Rocky9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM rockylinux:9
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 
-ENV LANG en_US.utf-8
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
+
+RUN dnf -y install epel-release
+RUN dnf install -y glibc-langpack-en
+ENV LANG en_US.utf-8
 
 RUN dnf -y install ansible sudo \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf install -y glibc-langpack-en
 ENV LANG en_US.utf-8
 
 RUN dnf -y install ansible-core sudo
-
+RUN ansible-galaxy collection install ansible.posix
 
 RUN ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
     && dnf -y clean all \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV LANG en_US.utf-8
 
 RUN dnf -y install ansible-core sudo
 RUN ansible-galaxy collection install ansible.posix
+RUN ansible-galaxy collection install community.general
 
 RUN ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
     && dnf -y clean all \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,15 @@ RUN dnf -y install epel-release
 RUN dnf install -y glibc-langpack-en
 ENV LANG en_US.utf-8
 
-RUN dnf -y install ansible sudo \
-    && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
+RUN dnf -y install ansible sudo
+
+
+RUN ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
     && dnf -y clean all \
     && rm -fr /var/cache
 
-RUN ansible-playbook playbook.yml \
-    && yum -y clean all \
+RUN ansible-playbook playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3' \
+    && dnf -y clean all \
     && rm -fr /var/cache
 
 RUN curl -L -o /usr/local/bin/dumb-init \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7.9.2009@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4
+FROM rockylinux:9
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 
 ENV LANG en_US.utf-8
@@ -7,10 +7,9 @@ RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
 
-RUN yum -y install epel-release \
-    && yum -y install ansible sudo \
+RUN dnf -y install ansible sudo \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
-    && yum -y clean all \
+    && dnf -y clean all \
     && rm -fr /var/cache
 
 RUN ansible-playbook playbook.yml \
@@ -18,7 +17,7 @@ RUN ansible-playbook playbook.yml \
     && rm -fr /var/cache
 
 RUN curl -L -o /usr/local/bin/dumb-init \
-    https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
+    https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64 && \
     chmod +x /usr/local/bin/dumb-init
 ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-default-web-config.sh 98-cleanprevious.sh 99-run.sh /startup/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN dnf -y install epel-release
 RUN dnf install -y glibc-langpack-en
 ENV LANG en_US.utf-8
 
-RUN dnf -y install ansible sudo
+RUN dnf -y install ansible-core sudo
 
 
 RUN ansible-galaxy install -p /opt/setup/roles -r requirements.yml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN ansible-playbook playbook.yml -e 'ansible_python_interpreter=/usr/bin/python
     && dnf -y clean all \
     && rm -fr /var/cache
 
+
 RUN curl -L -o /usr/local/bin/dumb-init \
-    https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64 && \
+    https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 && \
     chmod +x /usr/local/bin/dumb-init
 ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-default-web-config.sh 98-cleanprevious.sh 99-run.sh /startup/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Also see [SUPPORT.md](./SUPPORT.md)
 Running OMERO with docker-compose
 ---------------------------------
 
- The [omero-deployment-examples repository](https://github.com/ome/omero-deployment-examples/) repository
+The [omero-deployment-examples repository](https://github.com/ome/omero-deployment-examples/) repository
 contains a number of different ways of deployment OMERO. Unless you are looking for something
 specific, *we suggest starting with [docker-example-omero](https://github.com/ome/docker-example-omero).*
 
@@ -26,11 +26,12 @@ This image also includes these OMERO.web plugins with a default configuration:
 - [iviewer](https://www.openmicroscopy.org/omero/iviewer/)
 - [mapr](https://pypi.org/project/omero-mapr/)
 - [parade](https://pypi.org/project/omero-parade/)
+- [autotag](https://pypi.org/project/omero-autotag/)
+- [tagsearch](https://pypi.org/project/omero-webtagging-tagsearch)
 
 The following plugins are installed but disabled:
 - [fpbioimage](https://pypi.org/project/omero-fpbioimage/)
-- [autotag](https://pypi.org/project/omero-autotag/)
-- [tagsearch](https://pypi.org/project/omero-webtagging-tagsearch)
+
 
 To enable them or to change the configuration of a default plugin see the relevant plugin documentation.
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This image also includes these OMERO.web plugins with a default configuration:
 
 The following plugins are installed but disabled:
 - [fpbioimage](https://pypi.org/project/omero-fpbioimage/)
-- [autotag](https://pypi.org/project/omero-webtagging-autotag/)
-- [tagsearch](https://pypi.org/project/omero-webtagging-tagsearch/)
+- [autotag](https://pypi.org/project/omero-autotag/)
+- [tagsearch](https://pypi.org/project/omero-webtagging-tagsearch)
 
 To enable them or to change the configuration of a default plugin see the relevant plugin documentation.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ OMERO.web Docker
 
 [![Actions Status](https://github.com/ome/omero-web-docker/workflows/Build/badge.svg)](https://github.com/ome/omero-web-docker/actions)
 
-A CentOS 7 based Docker image for OMERO.web.
+A RockyLinux 9 based Docker image for OMERO.web.
 
 Also see [SUPPORT.md](./SUPPORT.md)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To enable them or to change the configuration of a default plugin see the releva
 
 To run the Docker image you can set a single OMERO.server to connect to by defining `OMEROHOST`:
 
-    docker run -d --name omero-web \
+    docker run -d --name omero-web-standalone \
         -e OMEROHOST=omero.example.org \
         -p 4080:4080 \
         openmicroscopy/omero-web-standalone

--- a/playbook.yml
+++ b/playbook.yml
@@ -3,10 +3,6 @@
   - role: ome.omero_web
   - role: ome.java
   vars:
-    ice_version: "3.6"
-    ice_install_devel: False
-    ice_install_python: False
-    ice_python_wheel: https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
     omero_web_systemd_setup: False
     omero_web_setup_nginx: False
     # These defaults can be overriden at runtime

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,4 @@
 # External Ansible roles required by this repository
-
-- name: ome.basedeps
-  src: https://github.com/pwalczysko/ansible-role-basedeps/
-  version: fix-repo-rhel
-
 - src: ome.java
   version: 2.2.0
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,8 +7,5 @@
 - src: ome.java
   version: 2.2.0
 
-- src: ome.omero_common
-  version: 0.4.0
-
 - name: ome.omero_web
   version: 5.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,13 +1,14 @@
 # External Ansible roles required by this repository
 
 - name: ome.basedeps
-  version: 1.2.0
+  src: https://github.com/pwalczysko/ansible-role-basedeps/
+  version: fix-repo-rhel
 
 - src: ome.java
-  version: 2.1.0
+  version: 2.2.0
 
 - src: ome.omero_common
-  version: 0.3.4
+  version: 0.4.0
 
 - name: ome.omero_web
-  version: 4.0.1
+  version: 5.0.0

--- a/standalone/01-default-webapps.omero
+++ b/standalone/01-default-webapps.omero
@@ -20,5 +20,15 @@ config append -- omero.web.mapr.config '{"menu": "anyvalue", "config":{"default"
 config append -- omero.web.apps '"omero_parade"'
 config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
 
+# Add autotag to webclient
+config append omero.web.apps '"omero_autotag"'
+config append omero.web.ui.center_plugins '["Auto Tag", "omero_autotag/auto_tag_init.js.html", "auto_tag_panel"]'
+
+# Add tagsearch to webclient
+config append omero.web.apps '"omero_tagsearch"'
+
+
 # Top links
 config set -- omero.web.ui.top_links '[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}], ["Mapr", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}], ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}], ["Help", "https://help.openmicroscopy.org/", {"title":"Open OMERO user guide in a new tab", "target":"new"}]]'
+
+config append omero.web.ui.top_links '["Tag Search", "tagsearch"]'

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -10,8 +10,8 @@ RUN /opt/omero/web/venv3/bin/pip install \
         omero-fpbioimage \
         omero-mapr \
         omero-parade \
-        omero-webtagging-autotag \
-        omero-webtagging-tagsearch \
+        omero-autotag \
+        omero-tagsearch \
         whitenoise
 
 ADD 01-default-webapps.omero /opt/omero/web/config/


### PR DESCRIPTION
This PR upgrades the Docker image to rocky9 so we can distribute the latest OMERO.web
See https://forum.image.sc/t/88699/1 for background
This PR also fixes the installation of autotag and tagsearch. We could consider extracting web-standalone from this repo but this is out of scope.
Note the current dependency on 
```
src: https://github.com/pwalczysko/ansible-role-basedeps/
version: fix-repo-rhel
```

This will be updated when a new version of the role is released

cc @pwalczysko @knabar @sbesson @khaledk2 
