### PR TITLE
Ubuntu2204

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,23 @@
-FROM centos:centos7.9.2009@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4
+FROM ubuntu:22.04
 LABEL maintainer="ome-devel@lists.openmicroscopy.org.uk"
 
 ENV LANG en_US.utf-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
 
-RUN yum -y install epel-release \
-    && yum -y install ansible sudo \
+RUN apt update \
+    && apt -y install ansible sudo dumb-init \
     && ansible-galaxy install -p /opt/setup/roles -r requirements.yml \
-    && yum -y clean all \
-    && rm -fr /var/cache
+    && apt -y autoclean autoremove \
+    && rm -fr /var/lib/apt/lists/* /tmp/*
 
 RUN ansible-playbook playbook.yml \
-    && yum -y clean all \
-    && rm -fr /var/cache
+    && apt -y autoclean autoremove \
+    && rm -fr /var/lib/apt/lists/* /tmp/*
 
-RUN curl -L -o /usr/local/bin/dumb-init \
-    https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
-    chmod +x /usr/local/bin/dumb-init
 ADD entrypoint.sh /usr/local/bin/
 ADD 50-config.py 60-default-web-config.sh 98-cleanprevious.sh 99-run.sh /startup/
 ADD ice.config /opt/omero/web/OMERO.web/etc/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/dumb-init /bin/bash
+#!/usr/bin/dumb-init /bin/bash
 
 set -e
 source /opt/omero/web/venv3/bin/activate

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,13 +1,3 @@
 # External Ansible roles required by this repository
 
-- name: ome.basedeps
-  version: 1.2.0
-
-- src: ome.java
-  version: 2.1.0
-
-- src: ome.omero_common
-  version: 0.3.4
-
 - name: ome.omero_web
-  version: 4.0.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,5 @@
 # External Ansible roles required by this repository
 
+- name: ome.basedeps
+- name: ome.java
 - name: ome.omero_web

--- a/standalone/01-default-webapps.omero
+++ b/standalone/01-default-webapps.omero
@@ -20,5 +20,14 @@ config append -- omero.web.mapr.config '{"menu": "anyvalue", "config":{"default"
 config append -- omero.web.apps '"omero_parade"'
 config append -- omero.web.ui.center_plugins '["Parade", "omero_parade/init.js.html", "omero_parade"]'
 
+# Add autotag to webclient
+config append omero.web.apps '"omero_autotag"'
+config append omero.web.ui.center_plugins '["Auto Tag", "omero_autotag/auto_tag_init.js.html", "auto_tag_panel"]'
+
+# Add tagsearch to webclient
+config append omero.web.apps '"omero_tagsearch"'
+
 # Top links
 config set -- omero.web.ui.top_links '[["Data", "webindex", {"title": "Browse Data via Projects, Tags etc"}],["History", "history", {"title": "History"}], ["Mapr", {"viewname": "maprindex_anyvalue"}, {"title": "Find Any Value"}], ["Figure", "figure_index", {"title": "Open Figure in new tab", "target": "_blank"}], ["Help", "https://help.openmicroscopy.org/", {"title":"Open OMERO user guide in a new tab", "target":"new"}]]'
+
+config append omero.web.ui.top_links '["Tag Search", "tagsearch"]'

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -10,8 +10,8 @@ RUN /opt/omero/web/venv3/bin/pip install \
         omero-fpbioimage \
         omero-mapr \
         omero-parade \
-        omero-webtagging-autotag \
-        omero-webtagging-tagsearch \
+        omero-autotag \
+        omero-tagsearch \
         whitenoise
 
 ADD 01-default-webapps.omero /opt/omero/web/config/


### PR DESCRIPTION
This PR upgrades the Docker image to Ubuntu22.04 so we can distribute the latest OMERO.web
See https://forum.image.sc/t/88699/1 for background
This PR also fixes the installation of autotag and tagsearch. 

This is an alternative to #75

cc @sbesson @pwalczysko @khaledk2 @knabar 