### PR TITLE
Upgrade to new roles

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -17,7 +17,7 @@ jobs:
   upload:
     needs: build
     if: startsWith(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       name: openmicroscopy/omero-web
     steps:
@@ -48,7 +48,7 @@ jobs:
   uploadstandalone:
       needs: upload
       if: startsWith(github.ref, 'refs/tags')
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04
       env:
         name: openmicroscopy/omero-web-standalone
         nameParent: openmicroscopy/omero-web:latest

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 # External Ansible roles required by this repository
 - src: ome.java
-  # version: 2.2.0
+  version: 2.3.0
 
 - name: ome.omero_web
-  # version: 5.0.0
+  version: 6.0.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 # External Ansible roles required by this repository
 - src: ome.java
-  version: 2.2.0
+  # version: 2.2.0
 
 - name: ome.omero_web
-  version: 5.0.0
+  # version: 5.0.0


### PR DESCRIPTION
Upgrading to the new ansible roles:

- bump versions to the recently released role versions (java, omero_web)
- Use the 24.04 in the testing framework, similarly to the tactics taken on the roles


The test is green - lucky enough that there were no hiccups. It is positively running on python 3.12 as checked in the test output and OMERO.web is litening on 4080.

cc @khaledk2 @jburel 

Edit: As a further test, I have pushed the image from this PR to my Dockerhub account, see https://hub.docker.com/r/pwalczysko/omero-web-standalone312/tags. I have edited up the ``docker-compose.yml`` on https://github.com/ome/docker-example-omero/blob/master/docker-compose.yml and started the 3 containers successfully, and logged in to OMERO.web.

<img width="728" height="395" alt="Screenshot 2025-11-21 at 16 25 54" src="https://github.com/user-attachments/assets/2b3e1348-01f8-455a-9da8-424c9e72f525" />


