### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Build
         run: ./build.sh
   upload:
@@ -54,7 +54,7 @@ jobs:
         nameParent: openmicroscopy/omero-web:latest
         folder: standalone
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v6
         - name: Get other tags
           id: gettags
           uses: jupyterhub/action-major-minor-tag-calculator@v2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ RUN mkdir /opt/setup
 WORKDIR /opt/setup
 ADD playbook.yml requirements.yml /opt/setup/
 
-RUN dnf -y install epel-release
-RUN dnf install -y glibc-langpack-en
+RUN dnf -y update && \
+    dnf -y install epel-release glibc-langpack-en ansible-core sudo ca-certificates && \
+    dnf clean all
 ENV LANG en_US.utf-8
 
-RUN dnf -y install ansible-core sudo
 RUN ansible-galaxy collection install ansible.posix
 RUN ansible-galaxy collection install community.general
 


### PR DESCRIPTION
Fixing the failure of the build to connect to fedora for epel.

See https://github.com/ome/omero-web-docker/actions/runs/29671990369/job/88341487690 -

```

38.62 TASK [ome.basedeps : Import a key for epel] ************************************
39.05 fatal: [localhost]: FAILED! => {"changed": false, "msg": "failed to fetch key at https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9 , error was: Connection failure: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4174)"}

```

NB: The error is not in the ome.basedeps role because it works on other repos (e.g. omero-server-docker). The problem was in the outdated framework, missing install of ca-certs and installation of the deps in the docker in peacemeal way.

Also bumping the version of actions/checkout to v6 as in other repos.

cc @jburel 