### PR TITLE
Upgrade versions of deprecated GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,24 +23,24 @@ jobs:
     steps:
       - name: Get other tags
         id: gettags
-        uses: jupyterhub/action-major-minor-tag-calculator@v2.0.0
+        uses: jupyterhub/action-major-minor-tag-calculator@v4
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prefix: "${{ env.name}}:"
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.name }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           tags: ${{ join(fromJson(steps.gettags.outputs.tags)) }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -57,17 +57,17 @@ jobs:
         - uses: actions/checkout@v6
         - name: Get other tags
           id: gettags
-          uses: jupyterhub/action-major-minor-tag-calculator@v2.0.0
+          uses: jupyterhub/action-major-minor-tag-calculator@v4
           with:
             githubToken: ${{ secrets.GITHUB_TOKEN }}
             prefix: "${{ env.name }}:"
         - name: Login to DockerHub
-          uses: docker/login-action@v1
+          uses: docker/login-action@v4
           with:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
         - name: Push to Docker Hub
-          uses: docker/build-push-action@v2
+          uses: docker/build-push-action@v7
           with:
             build-args: |
               "PARENT_IMAGE=${{ env.nameParent }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,8 @@ jobs:
           images: ${{ env.name }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
This is expected to assist the build of tagged Docker images which failed in https://github.com/ome/omero-web-docker/actions/runs/30798520653/job/91723117736 

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ and https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for the list of warnings raised by the current versions

/cc @knabar 